### PR TITLE
Resolve a NU1608 warning in the mvp-api.csproj

### DIFF
--- a/src/mvp-api/mvp-api.csproj
+++ b/src/mvp-api/mvp-api.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.6" />
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+    <PackageReference Include="Microsoft.Rest.ClientRuntime" Version="2.3.7" />
+    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Hi, I found a NU1608 warning in the mvp-api.csproj:

`Warning NU1608 Detected package version outside of dependency constraint: Microsoft.Rest.ClientRuntime 2.3.6 requires Newtonsoft.Json (>= 9.0.1 && < 10.0.0) but version Newtonsoft.Json 10.0.2 was resolved.`

This fix can remove this warnings from mvp-api-dot-net's dependency graph.
Hope the PR can help you.

Best regards,
sucrose